### PR TITLE
Fix invisible trains from entity culling

### DIFF
--- a/config/entityculling.json
+++ b/config/entityculling.json
@@ -1,0 +1,25 @@
+{
+  "configVersion": 5,
+  "renderNametagsThroughWalls": true,
+  "blockEntityWhitelist": [
+    "create:rope_pulley",
+    "minecraft:beacon",
+    "create:hose_pulley",
+    "betterend:eternal_pedestal"
+  ],
+  "entityWhitelist": [
+    "botania:mana_burst",
+    "create:carriage_contraption"
+  ],
+  "tracingDistance": 128,
+  "debugMode": false,
+  "sleepDelay": 10,
+  "hitboxLimit": 50,
+  "skipMarkerArmorStands": true,
+  "tickCulling": true,
+  "tickCullingWhitelist": [
+    "minecraft:boat",
+    "minecraft:firework_rocket"
+  ],
+  "disableF3": false
+}


### PR DESCRIPTION
This is the default config with the addition of `create:carriage_contraption` to the whitelist, which stops trains from disappearing when going out of render distance.

Related: https://github.com/tr7zw/EntityCulling/issues/84